### PR TITLE
Bumping nextra and other packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "next": "^11.1.2",
+    "next": "latest",
     "nextra": "^1.1.0",
     "nextra-theme-blog": "^0.1.5",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,7 +2128,7 @@ native-url@0.3.4:
   dependencies:
     querystring "^0.2.0"
 
-next@^11.1.2:
+next@latest:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/next/-/next-11.1.2.tgz#527475787a9a362f1bc916962b0c0655cc05bc91"
   integrity sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==


### PR DESCRIPTION
## Why?

When this template is currently used, customers would get this error message currently and might be confused about it. Even though it is working.

![portfolio-–-Deployment-Overview](https://user-images.githubusercontent.com/580672/136693102-f88e2428-32b7-4626-a206-9b00f62fdb1e.png)

## Solution proposal
Bump `nextra` version to `1.1.0`. It leads to having `0` errors and just two warnings.

## Additional changes
Smaller packages updated (yarn.lock)

- `grey-matter` to `4.0.3`
- `nextra-theme-blog` to `0.1.6`

## Tests

- [x] Checked it locally and through vercel deployments
- (!) I did not ran any automated tests, as there seems to be none existing in this repository
