### PR TITLE
Update next.config.js to make it easier to add plugins

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,2 +1,6 @@
-const withNextra = require('nextra')('nextra-theme-blog', './theme.config.js')
+const withNextra = require('nextra')({
+  theme: 'nextra-theme-blog',
+  themeConfig: './theme.config.js'
+})
+
 module.exports = withNextra()


### PR DESCRIPTION
The `theme` and `themeConfig` options are passed implicitly. When looking at plugins ([like LaTeX](https://nextra.site/docs/guide/advanced/latex)) it doesn't explain how to rewrite `next.config.js` to then pass `latex: true` as an additional parameter. Rewriting the template explicitly will make it easier for future user to quickly add plugins. 